### PR TITLE
small fix to require() transform

### DIFF
--- a/lib/build/browserify.js
+++ b/lib/build/browserify.js
@@ -137,8 +137,9 @@ function compile(bannerWidth, transforms) {
 
           // bower project
           } else {
-            var directory = path.resolve(path.join(BOWER, path.dirname(original)));
-            var isFound   = fs.existsSync(directory) && fs.statSync(directory).isDirectory();
+            var partial   = path.dirname(original);
+            var directory = (partial !== '.') && path.resolve(path.join(BOWER, partial));
+            var isFound   = directory && fs.existsSync(directory) && fs.statSync(directory).isDirectory();
             if (isFound) {
               transformed = slash(path.resolve(path.join(BOWER, original)));  // path is within the bower directory
             }
@@ -197,7 +198,7 @@ function compile(bannerWidth, transforms) {
             return (new RegExp('[\'"]' + analysis[1] + '[\'"]')).test(fileText);
           })
           .shift();
-        message = path.join(analysis[2], filename) + ':0:0: ' + analysis[1] + '\n';
+        message = path.join(analysis[2], filename) + ':0:0: Cannot find import ' + analysis[1] + '\n';
 
       // Unknown
       } else {

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -18,10 +18,10 @@ gulp.task('watch', ['server'], function () {
   });
 
   // watch statements
-  watch(streams.getGlob(['**/*.js', '!*.js', '!**/*.spec.js'], [streams.APP, streams.NODE, streams.BOWER]), {
-    name      : 'JS',
+  watch(streams.getGlob(['**/*.js', '**/*.html', '!*.*', '!**/*.spec.*'], [streams.APP, streams.NODE, streams.BOWER]), {
+    name      : 'JS|HTML',
     emitOnGlob: false
-  }, queue.getHandler('js', 'html', 'reload')); // html will be needed in case previous injection failed
+  }, queue.getHandler('js', 'html', 'reload')); // app html will be needed in case previous injection failed
 
   watch(streams.getGlob(['**/*.scss', '!*.scss'], [streams.APP, streams.NODE, streams.BOWER]), {
     name      : 'CSS',
@@ -30,11 +30,6 @@ gulp.task('watch', ['server'], function () {
 
   watch([streams.BOWER + '/**/*', '!**/*.js', '!**/*.scss'], {  // don't conflict with JS or CSS
     name      : 'BOWER',
-    emitOnGlob: false
-  }, queue.getHandler('html', 'reload'));
-
-  watch(streams.APP + '/**/*.html', {
-    name      : 'HTML',
     emitOnGlob: false
   }, queue.getHandler('html', 'reload'));
 


### PR DESCRIPTION
`require()` of a file adjacent to the current file (i.e. resolved directory of `./` ) was being confused as a bower file and being rewritten to a path in `bower_components`.