### PR TITLE
Plugin registry

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -9,13 +9,11 @@ var path        = require('path'),
     gulp        = require('gulp'),
     gutil       = require('gulp-util'),
     wordwrap    = require('wordwrap'),
-    runSequence = require('run-sequence'),
     chalk       = require('chalk'),
     prettyTime  = require('pretty-hrtime'),
     yargs       = require('yargs');
 
-var taskYargs     = require('../lib/util/task-yargs'),
-    taskYargsRun  = require('../lib/util/task-yargs-run');
+var taskYargsRun  = require('../lib/util/task-yargs-run');
 
 // we need to duplicate some event handlers from the gulp cli since we have bypassed it
 gulp.on('task_start', function (e) {
@@ -39,6 +37,7 @@ var helpOption = {
     boolean: true
   }
 };
+
 var defaultYargsInstance = yargs
   .usage(wordwrap(2, 80)([
     packageJson.description,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -9,11 +9,13 @@ var path        = require('path'),
     gulp        = require('gulp'),
     gutil       = require('gulp-util'),
     wordwrap    = require('wordwrap'),
+    runSequence = require('run-sequence'),
     chalk       = require('chalk'),
     prettyTime  = require('pretty-hrtime'),
     yargs       = require('yargs');
 
-var taskYargsRun  = require('../lib/util/task-yargs-run');
+var taskYargs     = require('../lib/util/task-yargs'),
+    taskYargsRun  = require('../lib/util/task-yargs-run');
 
 // TODO @bholloway menus
 // var mainMenu = require('../lib/cli/mainMenu');
@@ -49,8 +51,8 @@ var defaultYargsInstance = yargs
   ].join('\n')))
   // .example('angularity', 'Interactive menu') //TODO reinstate when interactive menu is reinstated
   .example('angularity -v', 'Display the version of angularity')
-  .example('angularity <task name> -h', 'Get help on a particular task')
-  .example('angularity <task name>', 'Run the given task')
+  .example('angularity \<task name\> -h', 'Get help on a particular task')
+  .example('angularity \<task name\>', 'Run the given task')
   .option('version', {
     describe: 'Display the curent version',
     alias: ['v'],
@@ -74,34 +76,27 @@ taskYargsRun.taskYargs.register('help', {
   checks: []
 });
 
-require('../index');
-
-//TODO move these to ../index.js
-require('../tasks/html')(taskYargsRun);
-require('../tasks/css')(taskYargsRun);
-require('../tasks/javascript')(taskYargsRun);
-require('../tasks/test')(taskYargsRun);
-require('../tasks/build')(taskYargsRun);
-require('../tasks/release')(taskYargsRun);
-require('../tasks/server')(taskYargsRun);
-require('../tasks/watch')(taskYargsRun);
-require('../tasks/init')(taskYargsRun);
-require('../tasks/webstorm')(taskYargsRun);
-
 var cliArgs;
-var taskName = taskYargsRun.taskYargs.getCurrentName();
-if (taskName) {
-  taskYargsRun.current();
+cliArgs = defaultYargsInstance.argv;
+if (cliArgs.version) {
+  console.log('angularity:', packageJson.version);
 }
 else {
-  cliArgs = defaultYargsInstance.argv;
-  if (cliArgs.version) {
-    console.log('angularity:', packageJson.version);
-  }
-  else {
+  if (cliArgs._.length < 1) {
     if (!cliArgs.help) {
-      console.log('Task specified is not recognised');
+      console.log('No task specified');
     }
     defaultYargsInstance.showHelp();
+  }
+  else {
+    require('../index');
+    var taskName = taskYargsRun.taskYargs.getCurrentName();
+    if (taskName) {
+      taskYargsRun.current();
+    }
+    else {
+      console.log('Task specified is not recognised');
+      defaultYargsInstance.showHelp();
+    }
   }
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -75,25 +75,26 @@ taskYargsRun.taskYargs.register('help', {
 
 var cliArgs;
 cliArgs = defaultYargsInstance.argv;
-if (cliArgs.version) {
-  console.log('angularity:', packageJson.version);
+var hasCommands = (cliArgs._.length > 0);
+if (hasCommands) {
+  require('../index');
+  var taskName = taskYargsRun.taskYargs.getCurrentName();
+  if (taskName) {
+    taskYargsRun.current();
+  }
+  else {
+    console.log('Task specified is not recognised');
+    defaultYargsInstance.showHelp();
+  }
 }
 else {
-  if (cliArgs._.length < 1) {
+  if (cliArgs.version) {
+    console.log('angularity:', packageJson.version);
+  }
+  else {
     if (!cliArgs.help) {
       console.log('No task specified');
     }
     defaultYargsInstance.showHelp();
-  }
-  else {
-    require('../index');
-    var taskName = taskYargsRun.taskYargs.getCurrentName();
-    if (taskName) {
-      taskYargsRun.current();
-    }
-    else {
-      console.log('Task specified is not recognised');
-      defaultYargsInstance.showHelp();
-    }
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var path            = require('path');
 
+var gulp            = require('gulp');
 var pluginRegistry  = require('plugin-registry');
 
 var taskYargsRun    = require('./lib/util/task-yargs-run');
@@ -38,7 +39,9 @@ if (configTaskPlugins.constructor !== Array) {
 }
 
 var pluginOptions = {
-  projectPath: __dirname
+  projectPath: __dirname,
+  gulp: gulp,
+  taskYargsRun: taskYargsRun
 };
 
 pluginRegistry
@@ -60,5 +63,5 @@ taskPlugins
       throw new Error('Plugin named ' + pluginDefinition.name + ' does not export a function');
     }
 
-    plugin(taskYargsRun);
+    plugin(pluginOptions);
   });

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 'use strict';
 var path            = require('path');
 
-var gulp            = require('gulp');
-var pluginRegistry  = require('plugin-registry');
+var gulp            = require('gulp'),
+    runSequence     = require('run-sequence'),
+    pluginRegistry  = require('plugin-registry');
 
 var taskYargsRun    = require('./lib/util/task-yargs-run');
 
@@ -38,15 +39,16 @@ if (configTaskPlugins.constructor !== Array) {
   throw new Error('Plugins defined in angularity.json should be an array');
 }
 
-var pluginOptions = {
-  projectPath: __dirname,
+var pluginContext = {
+  toolPath: __dirname,
+  taskYargsRun: taskYargsRun,
   gulp: gulp,
-  taskYargsRun: taskYargsRun
+  runSequence: runSequence
 };
 
 pluginRegistry
   .get('angularity')
-  .options(pluginOptions)
+  .options(pluginContext)
   .add(defaultTaskPlugins)
   .add(configTaskPlugins);
 
@@ -63,5 +65,6 @@ taskPlugins
       throw new Error('Plugin named ' + pluginDefinition.name + ' does not export a function');
     }
 
-    plugin(pluginOptions);
+    var taskDefinition = plugin(pluginContext);
+    taskYargsRun.taskYargs.register(taskDefinition);
   });

--- a/index.js
+++ b/index.js
@@ -1,1 +1,64 @@
 'use strict';
+var path            = require('path');
+
+var pluginRegistry  = require('plugin-registry');
+
+var taskYargsRun    = require('./lib/util/task-yargs-run');
+
+var defaultTaskPlugins = [
+  'html',
+  'css',
+  'javascript',
+  'test',
+  'build',
+  'release',
+  'server',
+  'watch',
+  'init',
+  'webstorm'
+].map(function parseDefaultPluginDefinition(taskName) {
+  return {
+    name: taskName,
+    requirePath: path.resolve(__dirname, 'tasks', taskName),
+    category: 'task',
+    isDefault: true
+  };
+});
+
+var angularityJson;
+try {
+  angularityJson = require(path.resolve('angularity.json'));
+}
+catch (ex) {
+  // Do nothing
+}
+var configTaskPlugins = (angularityJson && angularityJson.plugins) || [];
+if (configTaskPlugins.constructor !== Array) {
+  throw new Error('Plugins defined in angularity.json should be an array');
+}
+
+var pluginOptions = {
+  projectPath: __dirname
+};
+
+pluginRegistry
+  .get('angularity')
+  .options(pluginOptions)
+  .add(defaultTaskPlugins)
+  .add(configTaskPlugins);
+
+var taskPlugins = pluginRegistry
+  .get('angularity')
+  .getAllOfCategory('task');
+
+taskPlugins
+  .forEach(function eachTaskPlugin(pluginDefinition) {
+    var plugin = require(pluginDefinition.requirePath);
+
+    // Task plugins are expected to export a function which should be called with an instance of taskYargsRun
+    if (typeof plugin !== 'function') {
+      throw new Error('Plugin named ' + pluginDefinition.name + ' does not export a function');
+    }
+
+    plugin(taskYargsRun);
+  });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2797,81 +2797,81 @@
     },
     "ide-template": {
       "version": "2.2.1",
-      "from": "ide-template@2.2.1",
+      "from": "https://registry.npmjs.org/ide-template/-/ide-template-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/ide-template/-/ide-template-2.2.1.tgz",
       "dependencies": {
         "gulp": {
           "version": "3.8.8",
-          "from": "gulp@3.8.8",
+          "from": "https://registry.npmjs.org/gulp/-/gulp-3.8.8.tgz",
           "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.8.8.tgz",
           "dependencies": {
             "deprecated": {
               "version": "0.0.1",
-              "from": "deprecated@0.0.1",
+              "from": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
             },
             "interpret": {
               "version": "0.3.7",
-              "from": "interpret@0.3.7",
+              "from": "https://registry.npmjs.org/interpret/-/interpret-0.3.7.tgz",
               "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.3.7.tgz"
             },
             "liftoff": {
               "version": "0.12.1",
-              "from": "liftoff@0.12.1",
+              "from": "https://registry.npmjs.org/liftoff/-/liftoff-0.12.1.tgz",
               "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-0.12.1.tgz",
               "dependencies": {
                 "resolve": {
                   "version": "0.7.4",
-                  "from": "resolve@0.7.4",
+                  "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
                   "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
                 },
                 "minimist": {
                   "version": "0.2.0",
-                  "from": "minimist@0.2.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
                 },
                 "extend": {
                   "version": "1.3.0",
-                  "from": "extend@1.3.0",
+                  "from": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz"
                 }
               }
             },
             "minimist": {
               "version": "1.1.0",
-              "from": "minimist@1.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
             },
             "orchestrator": {
               "version": "0.3.7",
-              "from": "orchestrator@0.3.7",
+              "from": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
               "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
               "dependencies": {
                 "sequencify": {
                   "version": "0.0.7",
-                  "from": "sequencify@0.0.7",
+                  "from": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
                 },
                 "stream-consume": {
                   "version": "0.1.0",
-                  "from": "stream-consume@0.1.0",
+                  "from": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
                 }
               }
             },
             "semver": {
               "version": "3.0.1",
-              "from": "semver@3.0.1",
+              "from": "https://registry.npmjs.org/semver/-/semver-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-3.0.1.tgz"
             },
             "tildify": {
               "version": "1.0.0",
-              "from": "tildify@1.0.0",
+              "from": "https://registry.npmjs.org/tildify/-/tildify-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.0.0.tgz",
               "dependencies": {
                 "user-home": {
                   "version": "1.0.0",
-                  "from": "user-home@1.0.0",
+                  "from": "https://registry.npmjs.org/user-home/-/user-home-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.0.0.tgz"
                 }
               }
@@ -2883,12 +2883,12 @@
               "dependencies": {
                 "glob-stream": {
                   "version": "3.1.15",
-                  "from": "glob-stream@3.1.15",
+                  "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.15.tgz",
                   "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.15.tgz",
                   "dependencies": {
                     "glob": {
                       "version": "4.0.6",
-                      "from": "glob@4.0.6",
+                      "from": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz"
                     },
                     "ordered-read-streams": {
@@ -2898,7 +2898,7 @@
                     },
                     "unique-stream": {
                       "version": "1.0.0",
-                      "from": "unique-stream@1.0.0",
+                      "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
                     }
                   }
@@ -2910,12 +2910,12 @@
                 },
                 "mkdirp": {
                   "version": "0.5.0",
-                  "from": "mkdirp@0.5.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
@@ -2926,12 +2926,12 @@
         },
         "gulp-conflict": {
           "version": "0.2.0",
-          "from": "gulp-conflict@0.2.0",
+          "from": "https://registry.npmjs.org/gulp-conflict/-/gulp-conflict-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/gulp-conflict/-/gulp-conflict-0.2.0.tgz",
           "dependencies": {
             "through2": {
               "version": "0.4.2",
-              "from": "through2@0.4.2",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
               "dependencies": {
                 "readable-stream": {
@@ -2941,31 +2941,31 @@
                   "dependencies": {
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "2.1.2",
-                  "from": "xtend@2.1.2",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
                 }
               }
             },
             "gulp-util": {
               "version": "2.2.20",
-              "from": "gulp-util@2.2.20",
+              "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
               "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.2.0",
-                  "from": "minimist@0.2.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
                 },
                 "through2": {
                   "version": "0.5.1",
-                  "from": "through2@0.5.1",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "dependencies": {
                     "readable-stream": {
@@ -2975,7 +2975,7 @@
                       "dependencies": {
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
@@ -2984,39 +2984,39 @@
                 },
                 "vinyl": {
                   "version": "0.2.3",
-                  "from": "vinyl@0.2.3",
+                  "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz"
                 }
               }
             },
             "inquirer": {
               "version": "0.5.1",
-              "from": "inquirer@0.5.1",
+              "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.5.1.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.8.0",
-                  "from": "async@0.8.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.8.0.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.8.0.tgz"
                 },
                 "through": {
                   "version": "2.3.6",
-                  "from": "through@2.3.6",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 },
                 "chalk": {
                   "version": "0.4.0",
-                  "from": "chalk@0.4.0",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "1.0.0",
-                      "from": "ansi-styles@1.0.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                     },
                     "strip-ansi": {
                       "version": "0.1.1",
-                      "from": "strip-ansi@0.1.1",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                     }
                   }
@@ -3025,19 +3025,19 @@
             },
             "diff": {
               "version": "1.0.8",
-              "from": "diff@1.0.8",
+              "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
               "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
             }
           }
         },
         "template": {
           "version": "0.2.1",
-          "from": "template@0.2.1",
+          "from": "https://registry.npmjs.org/template/-/template-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/template/-/template-0.2.1.tgz",
           "dependencies": {
             "delims": {
               "version": "0.1.4",
-              "from": "delims@0.1.4",
+              "from": "https://registry.npmjs.org/delims/-/delims-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/delims/-/delims-0.1.4.tgz"
             }
           }
@@ -4001,6 +4001,175 @@
       "version": "1.0.0",
       "from": "https://registry.npmjs.org/opn/-/opn-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.0.tgz"
+    },
+    "plugin-registry": {
+      "version": "0.0.4",
+      "dependencies": {
+        "rimraf": {
+          "version": "2.3.2",
+          "from": "rimraf@",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "4.5.3",
+              "from": "glob@^4.4.2",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@^1.0.4",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.4",
+                  "from": "minimatch@^2.0.1",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@^0.2.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@^1.3.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "jasmine-node": {
+          "version": "2.0.0",
+          "from": "jasmine-node@2",
+          "resolved": "https://registry.npmjs.org/jasmine-node/-/jasmine-node-2.0.0.tgz",
+          "dependencies": {
+            "coffee-script": {
+              "version": "1.7.1",
+              "from": "coffee-script@~1.7.1",
+              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz"
+            },
+            "walkdir": {
+              "version": "0.0.7",
+              "from": "walkdir@~0.0.7",
+              "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.7.tgz"
+            },
+            "underscore": {
+              "version": "1.6.0",
+              "from": "underscore@~1.6.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+            },
+            "gaze": {
+              "version": "0.5.1",
+              "from": "gaze@~0.5.1",
+              "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+              "dependencies": {
+                "globule": {
+                  "version": "0.1.0",
+                  "from": "globule@~0.1.0",
+                  "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "1.0.1",
+                      "from": "lodash@~1.0.1",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
+                    },
+                    "glob": {
+                      "version": "3.1.21",
+                      "from": "glob@~3.1.21",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "1.2.3",
+                          "from": "graceful-fs@~1.2.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                        },
+                        "inherits": {
+                          "version": "1.0.0",
+                          "from": "inherits@1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "minimatch@~0.2.11",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@~0.3.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            },
+            "jasmine-growl-reporter": {
+              "version": "0.2.1",
+              "from": "jasmine-growl-reporter@~0.2.0",
+              "resolved": "https://registry.npmjs.org/jasmine-growl-reporter/-/jasmine-growl-reporter-0.2.1.tgz",
+              "dependencies": {
+                "growl": {
+                  "version": "1.7.0",
+                  "from": "growl@~1.7.0",
+                  "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "pretty-hrtime": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "minifyify": "latest",
     "minimatch": "latest",
     "node-sass": "latest",
+    "plugin-registry": "latest",
     "pretty-hrtime": "latest",
     "q": "latest",
     "request-progress": "latest",

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -27,7 +27,7 @@ function setUpTaskBuild(context) {
     },
     onRun: function onBuildTask() {
       var gulp        = context.gulp;
-      gulp.start.apply(gulp, [taskDefinition.name]);
+      gulp.start(taskDefinition.name);
     }
   };
 

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function setUpTaskBuild(tyRun) {
+function setUpTaskBuild(options) {
   var taskDefinition = {
     name: 'build',
     description: ('The "build" task performs a single build of the javascript and SASS composition root(s).'),
@@ -8,7 +8,7 @@ function setUpTaskBuild(tyRun) {
     checks: [],
     options: [],
     onInit: function onBuildTask() {
-      var gulp        = require('gulp'),
+      var gulp        = options.gulp || require('gulp'),
           runSequence = require('run-sequence');
 
       var hr          = require('../lib/util/hr');
@@ -19,12 +19,12 @@ function setUpTaskBuild(tyRun) {
       });
     },
     onRun: function onBuildTask() {
-      var runSequence = require('run-sequence');
-      runSequence(taskDefinition.name);
+      var gulp        = options.gulp || require('gulp');
+      gulp.run(taskDefinition.name);
     }
   };
 
-  tyRun.taskYargs.register(taskDefinition);
+  options.taskYargsRun.taskYargs.register(taskDefinition);
 }
 
 module.exports = setUpTaskBuild;

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -20,7 +20,7 @@ function setUpTaskBuild(options) {
     },
     onRun: function onBuildTask() {
       var gulp        = options.gulp || require('gulp');
-      gulp.run(taskDefinition.name);
+      gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
 

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -1,6 +1,13 @@
 'use strict';
 
-function setUpTaskBuild(options) {
+function setUpTaskBuild(context) {
+  if (!context.gulp) {
+    throw new Error('Context must specify gulp instance');
+  }
+  if (!context.runSequence) {
+    throw new Error('Context must specify run-sequence instance');
+  }
+
   var taskDefinition = {
     name: 'build',
     description: ('The "build" task performs a single build of the javascript and SASS composition root(s).'),
@@ -8,8 +15,8 @@ function setUpTaskBuild(options) {
     checks: [],
     options: [],
     onInit: function onBuildTask() {
-      var gulp        = options.gulp || require('gulp'),
-          runSequence = require('run-sequence');
+      var gulp        = context.gulp,
+          runSequence = context.runSequence;
 
       var hr          = require('../lib/util/hr');
 
@@ -19,12 +26,12 @@ function setUpTaskBuild(options) {
       });
     },
     onRun: function onBuildTask() {
-      var gulp        = options.gulp || require('gulp');
+      var gulp        = context.gulp;
       gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
 
-  options.taskYargsRun.taskYargs.register(taskDefinition);
+  return taskDefinition;
 }
 
 module.exports = setUpTaskBuild;

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -47,7 +47,7 @@ function setUpTaskCss(context) {
     },
     onRun: function onRunCssTask() {
       var gulp        = context.gulp;
-      gulp.start.apply(gulp, [taskDefinition.name]);
+      gulp.start(taskDefinition.name);
     }
   };
 

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -1,6 +1,13 @@
 'use strict';
 
-function setUpTaskCss(options) {
+function setUpTaskCss(context) {
+  if (!context.gulp) {
+    throw new Error('Context must specify gulp instance');
+  }
+  if (!context.runSequence) {
+    throw new Error('Context must specify run-sequence instance');
+  }
+
   var taskDefinition = {
     name: 'css',
     description: ('The "css" task performs a one time build of the SASS composition root(s).'),
@@ -8,9 +15,9 @@ function setUpTaskCss(options) {
     checks: [],
     options: [],
     onInit: function onInitCssTask() {
-      var gulp            = options.gulp || require('gulp'),
-          rimraf          = require('gulp-rimraf'),
-          runSequence     = require('run-sequence');
+      var gulp            = context.gulp,
+          runSequence     = context.runSequence,
+          rimraf          = require('gulp-rimraf');
 
       var nodeSass        = require('../lib/build/node-sass'),
           hr              = require('../lib/util/hr'),
@@ -39,11 +46,12 @@ function setUpTaskCss(options) {
       });
     },
     onRun: function onRunCssTask() {
-      var gulp        = options.gulp || require('gulp');
+      var gulp        = context.gulp;
       gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
-  options.taskYargsRun.taskYargs.register(taskDefinition);
+
+  return taskDefinition;
 }
 
 module.exports = setUpTaskCss;

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -40,7 +40,7 @@ function setUpTaskCss(options) {
     },
     onRun: function onRunCssTask() {
       var gulp        = options.gulp || require('gulp');
-      gulp.run(taskDefinition.name);
+      gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
   options.taskYargsRun.taskYargs.register(taskDefinition);

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function setUpTaskCss(tyRun) {
+function setUpTaskCss(options) {
   var taskDefinition = {
     name: 'css',
     description: ('The "css" task performs a one time build of the SASS composition root(s).'),
@@ -8,7 +8,7 @@ function setUpTaskCss(tyRun) {
     checks: [],
     options: [],
     onInit: function onInitCssTask() {
-      var gulp            = require('gulp'),
+      var gulp            = options.gulp || require('gulp'),
           rimraf          = require('gulp-rimraf'),
           runSequence     = require('run-sequence');
 
@@ -39,11 +39,11 @@ function setUpTaskCss(tyRun) {
       });
     },
     onRun: function onRunCssTask() {
-      var runSequence = require('run-sequence');
-      runSequence(taskDefinition.name);
+      var gulp        = options.gulp || require('gulp');
+      gulp.run(taskDefinition.name);
     }
   };
-  tyRun.taskYargs.register(taskDefinition);
+  options.taskYargsRun.taskYargs.register(taskDefinition);
 }
 
 module.exports = setUpTaskCss;

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function setUpTaskHtml(tyRun) {
+function setUpTaskHtml(options) {
   var taskDefinition = {
     name: 'html',
     description: ('The "html" task performs a one time injection of ' +
@@ -9,7 +9,7 @@ function setUpTaskHtml(tyRun) {
     checks: [],
     options: [],
     onInit: function onInitHtmlTask() {
-      var gulp            = require('gulp'),
+      var gulp            = options.gulp || require('gulp'),
           inject          = require('gulp-inject'),
           plumber         = require('gulp-plumber'),
           rimraf          = require('gulp-rimraf'),
@@ -58,11 +58,11 @@ function setUpTaskHtml(tyRun) {
       });
     },
     onRun: function onRunHtmlTask() {
-      var runSequence = require('run-sequence');
-      runSequence(taskDefinition.name);
+      var gulp        = options.gulp || require('gulp');
+      gulp.run(taskDefinition.name);
     }
   };
-  tyRun.taskYargs.register(taskDefinition);
+  options.taskYargsRun.taskYargs.register(taskDefinition);
 }
 
 module.exports = setUpTaskHtml;

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -59,7 +59,7 @@ function setUpTaskHtml(options) {
     },
     onRun: function onRunHtmlTask() {
       var gulp        = options.gulp || require('gulp');
-      gulp.run(taskDefinition.name);
+      gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
   options.taskYargsRun.taskYargs.register(taskDefinition);

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -66,7 +66,7 @@ function setUpTaskHtml(context) {
     },
     onRun: function onRunHtmlTask() {
       var gulp        = context.gulp;
-      gulp.start.apply(gulp, [taskDefinition.name]);
+      gulp.start(taskDefinition.name);
     }
   };
 

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -1,6 +1,13 @@
 'use strict';
 
-function setUpTaskHtml(options) {
+function setUpTaskHtml(context) {
+  if (!context.gulp) {
+    throw new Error('Context must specify gulp instance');
+  }
+  if (!context.runSequence) {
+    throw new Error('Context must specify run-sequence instance');
+  }
+
   var taskDefinition = {
     name: 'html',
     description: ('The "html" task performs a one time injection of ' +
@@ -9,11 +16,11 @@ function setUpTaskHtml(options) {
     checks: [],
     options: [],
     onInit: function onInitHtmlTask() {
-      var gulp            = options.gulp || require('gulp'),
+      var gulp            = context.gulp,
+          runSequence     = context.runSequence,
           inject          = require('gulp-inject'),
           plumber         = require('gulp-plumber'),
-          rimraf          = require('gulp-rimraf'),
-          runSequence     = require('run-sequence');
+          rimraf          = require('gulp-rimraf');
 
       var injectAdjacent  = require('../lib/inject/adjacent-files'),
           bowerFiles      = require('../lib/inject/bower-files'),
@@ -58,11 +65,12 @@ function setUpTaskHtml(options) {
       });
     },
     onRun: function onRunHtmlTask() {
-      var gulp        = options.gulp || require('gulp');
+      var gulp        = context.gulp;
       gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
-  options.taskYargsRun.taskYargs.register(taskDefinition);
+
+  return taskDefinition;
 }
 
 module.exports = setUpTaskHtml;

--- a/tasks/init.js
+++ b/tasks/init.js
@@ -372,7 +372,7 @@ function setUpInitTask(context) {
     },
     onRun: function onRunInitTask() {
       var gulp        = context.gulp;
-      gulp.start.apply(gulp, [taskDefinition.name]);
+      gulp.start(taskDefinition.name);
     }
   };
 

--- a/tasks/init.js
+++ b/tasks/init.js
@@ -1,6 +1,16 @@
 'use strict';
 
-function setUpInitTask(options) {
+function setUpInitTask(context) {
+  if (!context.gulp) {
+    throw new Error('Context must specify gulp instance');
+  }
+  if (!context.runSequence) {
+    throw new Error('Context must specify run-sequence instance');
+  }
+  if (!context.taskYargsRun) {
+    throw new Error('Context must specify task-yargs run instance');
+  }
+
   var platform        = require('../lib/config/platform'),
       defaults        = require('../lib/config/defaults');
 
@@ -128,7 +138,7 @@ function setUpInitTask(options) {
   ];
 
   function checkInitFlags(argv) {
-    var tyRun = options.taskYargsRun;
+    var tyRun = context.taskYargsRun;
 
     if (argv.help) {
       return true;
@@ -206,9 +216,9 @@ function setUpInitTask(options) {
     checks: [checkInitFlags],
     options: initOptionDefinitions,
     onInit: function onInitInitTask(yargsInstance) {
-      var gulp        = options.gulp || require('gulp'),
+      var gulp        = context.gulp,
+          runSequence = context.runSequence,
           gutil       = require('gulp-util'),
-          runSequence = require('run-sequence'),
           path        = require('path'),
           fs          = require('fs'),
           template    = require('lodash.template'),
@@ -361,12 +371,12 @@ function setUpInitTask(options) {
       }
     },
     onRun: function onRunInitTask() {
-      var gulp        = options.gulp || require('gulp');
+      var gulp        = context.gulp;
       gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
 
-  options.taskYargsRun.taskYargs.register(taskDefinition);
+  return taskDefinition;
 }
 
 module.exports = setUpInitTask;

--- a/tasks/init.js
+++ b/tasks/init.js
@@ -128,6 +128,8 @@ function setUpInitTask(options) {
   ];
 
   function checkInitFlags(argv) {
+    var tyRun = options.taskYargsRun;
+
     if (argv.help) {
       return true;
     }
@@ -360,7 +362,7 @@ function setUpInitTask(options) {
     },
     onRun: function onRunInitTask() {
       var gulp        = options.gulp || require('gulp');
-      gulp.run(taskDefinition.name);
+      gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
 

--- a/tasks/init.js
+++ b/tasks/init.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function setUpInitTask(tyRun) {
+function setUpInitTask(options) {
   var platform        = require('../lib/config/platform'),
       defaults        = require('../lib/config/defaults');
 
@@ -204,7 +204,7 @@ function setUpInitTask(tyRun) {
     checks: [checkInitFlags],
     options: initOptionDefinitions,
     onInit: function onInitInitTask(yargsInstance) {
-      var gulp        = require('gulp'),
+      var gulp        = options.gulp || require('gulp'),
           gutil       = require('gulp-util'),
           runSequence = require('run-sequence'),
           path        = require('path'),
@@ -359,12 +359,12 @@ function setUpInitTask(tyRun) {
       }
     },
     onRun: function onRunInitTask() {
-      var runSequence = require('run-sequence');
-      runSequence(taskDefinition.name);
+      var gulp        = options.gulp || require('gulp');
+      gulp.run(taskDefinition.name);
     }
   };
 
-  tyRun.taskYargs.register(taskDefinition);
+  options.taskYargsRun.taskYargs.register(taskDefinition);
 }
 
 module.exports = setUpInitTask;

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -1,6 +1,13 @@
 'use strict';
 
-function setUpTaskJavascript(options) {
+function setUpTaskJavascript(context) {
+  if (!context.gulp) {
+    throw new Error('Context must specify gulp instance');
+  }
+  if (!context.runSequence) {
+    throw new Error('Context must specify run-sequence instance');
+  }
+
   var jshintReporter  = require('../lib/util/jshint-reporter');
   var karma           = require('../lib/test/karma');
 
@@ -98,11 +105,11 @@ function setUpTaskJavascript(options) {
       checkKarmaReporter
     ],
     onInit: function onInitJavascriptTask(yargsInstance) {
-      var gulp            = options.gulp || require('gulp'),
+      var gulp            = context.gulp,
+          runSequence     = context.runSequence,
           jshint          = require('gulp-jshint'),
           rimraf          = require('gulp-rimraf'),
           semiflat        = require('gulp-semiflat'),
-          runSequence     = require('run-sequence'),
           combined        = require('combined-stream'),
           to5ify          = require('6to5ify'),
           stringify       = require('stringify'),
@@ -203,12 +210,12 @@ function setUpTaskJavascript(options) {
       }
     },
     onRun: function onRunJavascriptTask() {
-      var gulp        = options.gulp || require('gulp');
+      var gulp        = context.gulp;
       gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
 
-  options.taskYargsRun.taskYargs.register(taskDefinition);
+  return taskDefinition;
 }
 
 module.exports = setUpTaskJavascript;

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function setUpTaskJavascript(tyRun) {
+function setUpTaskJavascript(options) {
   var jshintReporter  = require('../lib/util/jshint-reporter');
   var karma           = require('../lib/test/karma');
 
@@ -98,7 +98,7 @@ function setUpTaskJavascript(tyRun) {
       checkKarmaReporter
     ],
     onInit: function onInitJavascriptTask(yargsInstance) {
-      var gulp            = require('gulp'),
+      var gulp            = options.gulp || require('gulp'),
           jshint          = require('gulp-jshint'),
           rimraf          = require('gulp-rimraf'),
           semiflat        = require('gulp-semiflat'),
@@ -209,13 +209,12 @@ function setUpTaskJavascript(tyRun) {
       setUpTaskJavascript.getTransforms = getTransforms;
     },
     onRun: function onRunJavascriptTask() {
-      console.log('onRunJavascriptTask');
-      var runSequence = require('run-sequence');
-      runSequence(taskDefinition.name);
+      var gulp        = options.gulp || require('gulp');
+      gulp.run(taskDefinition.name);
     }
   };
 
-  tyRun.taskYargs.register(taskDefinition);
+  options.taskYargsRun.taskYargs.register(taskDefinition);
 }
 
 module.exports = setUpTaskJavascript;

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -210,7 +210,7 @@ function setUpTaskJavascript(options) {
     },
     onRun: function onRunJavascriptTask() {
       var gulp        = options.gulp || require('gulp');
-      gulp.run(taskDefinition.name);
+      gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
 

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -211,7 +211,7 @@ function setUpTaskJavascript(context) {
     },
     onRun: function onRunJavascriptTask() {
       var gulp        = context.gulp;
-      gulp.start.apply(gulp, [taskDefinition.name]);
+      gulp.start(taskDefinition.name);
     }
   };
 

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -85,7 +85,7 @@ function setUpTaskRelease(options) {
     },
     onRun: function onRunReleaseTask() {
       var gulp        = options.gulp || require('gulp');
-      gulp.run(taskDefinition.name);
+      gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
   options.taskYargsRun.taskYargs.register(taskDefinition);

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -21,8 +21,7 @@ function setUpTaskRelease(context) {
           inject      = require('gulp-inject'),
           plumber     = require('gulp-plumber'),
           rimraf      = require('gulp-rimraf'),
-          semiflat    = require('gulp-semiflat'),
-          wordwrap    = require('wordwrap');
+          semiflat    = require('gulp-semiflat');
 
       var injectAdjacent   = require('../lib/inject/adjacent-files'),
           injectTransform  = require('../lib/inject/relative-transform'),
@@ -83,7 +82,7 @@ function setUpTaskRelease(context) {
     },
     onRun: function onRunReleaseTask() {
       var gulp        = context.gulp;
-      gulp.start.apply(gulp, [taskDefinition.name]);
+      gulp.start(taskDefinition.name);
     }
   };
 

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function setUpTaskRelease(tyRun) {
+function setUpTaskRelease(options) {
   var taskDefinition = {
     name: 'release',
     description: ('The "release" task performs a single build and exports the build files along with bower ' +
@@ -9,7 +9,7 @@ function setUpTaskRelease(tyRun) {
     checks: [],
     options: [],
     onInit: function onInitReleaseTask() {
-      var gulp        = require('gulp'),
+      var gulp        = options.gulp || require('gulp'),
           inject      = require('gulp-inject'),
           plumber     = require('gulp-plumber'),
           rimraf      = require('gulp-rimraf'),
@@ -84,11 +84,11 @@ function setUpTaskRelease(tyRun) {
       */
     },
     onRun: function onRunReleaseTask() {
-      var runSequence = require('run-sequence');
-      runSequence(taskDefinition.name);
+      var gulp        = options.gulp || require('gulp');
+      gulp.run(taskDefinition.name);
     }
   };
-  tyRun.taskYargs.register(taskDefinition);
+  options.taskYargsRun.taskYargs.register(taskDefinition);
 }
 
 module.exports = setUpTaskRelease;

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -1,6 +1,13 @@
 'use strict';
 
-function setUpTaskRelease(options) {
+function setUpTaskRelease(context) {
+  if (!context.gulp) {
+    throw new Error('Context must specify gulp instance');
+  }
+  if (!context.runSequence) {
+    throw new Error('Context must specify run-sequence instance');
+  }
+
   var taskDefinition = {
     name: 'release',
     description: ('The "release" task performs a single build and exports the build files along with bower ' +
@@ -9,28 +16,19 @@ function setUpTaskRelease(options) {
     checks: [],
     options: [],
     onInit: function onInitReleaseTask() {
-      var gulp        = options.gulp || require('gulp'),
+      var gulp        = context.gulp,
+          runSequence = context.runSequence,
           inject      = require('gulp-inject'),
           plumber     = require('gulp-plumber'),
           rimraf      = require('gulp-rimraf'),
           semiflat    = require('gulp-semiflat'),
-          wordwrap    = require('wordwrap'),
-          runSequence = require('run-sequence');
+          wordwrap    = require('wordwrap');
 
       var injectAdjacent   = require('../lib/inject/adjacent-files'),
           injectTransform  = require('../lib/inject/relative-transform'),
           bowerFiles       = require('../lib/inject/bower-files'),
-          taskYargs        = require('../lib/util/task-yargs'),
           hr               = require('../lib/util/hr'),
           streams          = require('../lib/config/streams');
-
-      taskYargs.register('release', {
-        description: (wordwrap(2, 80)('The "release" task performs a single build and exports the build ' +
-        'files along with bower components to a release directory.')),
-        prerequisiteTasks: ['help', 'build'],
-        checks: [],
-        options: []
-      });
 
       gulp.task('release', ['build'], function (done) {
         console.log(hr('-', 80, 'release'));
@@ -84,11 +82,12 @@ function setUpTaskRelease(options) {
       */
     },
     onRun: function onRunReleaseTask() {
-      var gulp        = options.gulp || require('gulp');
+      var gulp        = context.gulp;
       gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
-  options.taskYargsRun.taskYargs.register(taskDefinition);
+
+  return taskDefinition;
 }
 
 module.exports = setUpTaskRelease;

--- a/tasks/server.js
+++ b/tasks/server.js
@@ -81,7 +81,7 @@ function setUpTaskServer(context) {
     },
     onRun: function onRunServerTask() {
       var gulp        = context.gulp;
-      gulp.start.apply(gulp, [taskDefinition.name]);
+      gulp.start(taskDefinition.name);
     }
   };
 

--- a/tasks/server.js
+++ b/tasks/server.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function setUpTaskServer(tyRun) {
+function setUpTaskServer(options) {
   var defaults = require('../lib/config/defaults');
   var config = defaults.getInstance()
     .file('angularity.json')
@@ -38,7 +38,7 @@ function setUpTaskServer(tyRun) {
       }
     ],
     onInit: function onInitServerTask(yargsInstance) {
-      var gulp        = require('gulp'),
+      var gulp        = options.gulp || require('gulp'),
           gutil       = require('gulp-util'),
           browserSync = require('browser-sync');
 
@@ -76,11 +76,11 @@ function setUpTaskServer(tyRun) {
       });
     },
     onRun: function onRunServerTask() {
-      var runSequence = require('run-sequence');
-      runSequence(taskDefinition.name);
+      var gulp        = options.gulp || require('gulp');
+      gulp.run(taskDefinition.name);
     }
   };
-  tyRun.taskYargs.register(taskDefinition);
+  options.taskYargsRun.taskYargs.register(taskDefinition);
 }
 
 module.exports = setUpTaskServer;

--- a/tasks/server.js
+++ b/tasks/server.js
@@ -77,7 +77,7 @@ function setUpTaskServer(options) {
     },
     onRun: function onRunServerTask() {
       var gulp        = options.gulp || require('gulp');
-      gulp.run(taskDefinition.name);
+      gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
   options.taskYargsRun.taskYargs.register(taskDefinition);

--- a/tasks/server.js
+++ b/tasks/server.js
@@ -1,6 +1,10 @@
 'use strict';
 
-function setUpTaskServer(options) {
+function setUpTaskServer(context) {
+  if (!context.gulp) {
+    throw new Error('Context must specify gulp instance');
+  }
+
   var defaults = require('../lib/config/defaults');
   var config = defaults.getInstance()
     .file('angularity.json')
@@ -38,7 +42,7 @@ function setUpTaskServer(options) {
       }
     ],
     onInit: function onInitServerTask(yargsInstance) {
-      var gulp        = options.gulp || require('gulp'),
+      var gulp        = context.gulp,
           gutil       = require('gulp-util'),
           browserSync = require('browser-sync');
 
@@ -76,11 +80,12 @@ function setUpTaskServer(options) {
       });
     },
     onRun: function onRunServerTask() {
-      var gulp        = options.gulp || require('gulp');
+      var gulp        = context.gulp;
       gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
-  options.taskYargsRun.taskYargs.register(taskDefinition);
+
+  return taskDefinition;
 }
 
 module.exports = setUpTaskServer;

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -39,7 +39,7 @@ function setUpTaskTest(context) {
     },
     onRun: function onRunTestTask() {
       var gulp        = context.gulp;
-      gulp.start.apply(gulp, [taskDefinition.name]);
+      gulp.start(taskDefinition.name);
     }
   };
 

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function setUpTaskTest(tyRun) {
+function setUpTaskTest(options) {
   var taskDefinition = {
     name: 'test',
     description: [
@@ -13,7 +13,7 @@ function setUpTaskTest(tyRun) {
     options: [],
     checks: [],
     onInit: function onInitTestTask(yargsInstance) {
-      var gulp            = require('gulp');
+      var gulp            = options.gulp || require('gulp');
 
       var karma           = require('../lib/test/karma'),
           hr              = require('../lib/util/hr'),
@@ -34,11 +34,11 @@ function setUpTaskTest(tyRun) {
       });
     },
     onRun: function onRunTestTask() {
-      var runSequence = require('run-sequence');
-      runSequence(taskDefinition.name);
+      var gulp        = options.gulp || require('gulp');
+      gulp.run(taskDefinition.name);
     }
   };
-  tyRun.taskYargs.register(taskDefinition);
+  options.taskYargsRun.taskYargs.register(taskDefinition);
 }
 
 module.exports = setUpTaskTest;

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -1,6 +1,10 @@
 'use strict';
 
-function setUpTaskTest(options) {
+function setUpTaskTest(context) {
+  if (!context.gulp) {
+    throw new Error('Context must specify gulp instance');
+  }
+
   var taskDefinition = {
     name: 'test',
     description: [
@@ -13,7 +17,7 @@ function setUpTaskTest(options) {
     options: [],
     checks: [],
     onInit: function onInitTestTask(yargsInstance) {
-      var gulp            = options.gulp || require('gulp');
+      var gulp            = context.gulp;
 
       var karma           = require('../lib/test/karma'),
           hr              = require('../lib/util/hr'),
@@ -34,11 +38,12 @@ function setUpTaskTest(options) {
       });
     },
     onRun: function onRunTestTask() {
-      var gulp        = options.gulp || require('gulp');
+      var gulp        = context.gulp;
       gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
-  options.taskYargsRun.taskYargs.register(taskDefinition);
+
+  return taskDefinition;
 }
 
 module.exports = setUpTaskTest;

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -35,7 +35,7 @@ function setUpTaskTest(options) {
     },
     onRun: function onRunTestTask() {
       var gulp        = options.gulp || require('gulp');
-      gulp.run(taskDefinition.name);
+      gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
   options.taskYargsRun.taskYargs.register(taskDefinition);

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -53,7 +53,7 @@ function setUpTaskWatch(context) {
     },
     onRun: function onRunWatchTask() {
       var gulp        = context.gulp;
-      gulp.start.apply(gulp, [taskDefinition.name]);
+      gulp.start(taskDefinition.name);
     }
   };
 

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function setUpTaskWatch(tyRun) {
+function setUpTaskWatch(options) {
   var taskDefinition = {
     name: 'watch',
     description: ('The "watch" task performs an initial build and then serves the application on localhost at ' +
@@ -10,7 +10,7 @@ function setUpTaskWatch(tyRun) {
     checks: [],
     options: [],
     onInit: function onInitWatchTask() {
-      var gulp          = require('gulp'),
+      var gulp          = options.gulp || require('gulp'),
           watch         = require('gulp-watch'),
           watchSequence = require('gulp-watch-sequence');
 
@@ -45,12 +45,12 @@ function setUpTaskWatch(tyRun) {
       });
     },
     onRun: function onRunWatchTask() {
-      var runSequence = require('run-sequence');
-      runSequence(taskDefinition.name);
+      var gulp        = options.gulp || require('gulp');
+      gulp.run(taskDefinition.name);
     }
   };
 
-  tyRun.taskYargs.register(taskDefinition);
+  options.taskYargsRun.taskYargs.register(taskDefinition);
 }
 
 module.exports = setUpTaskWatch;

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -46,7 +46,7 @@ function setUpTaskWatch(options) {
     },
     onRun: function onRunWatchTask() {
       var gulp        = options.gulp || require('gulp');
-      gulp.run(taskDefinition.name);
+      gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
 

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -1,6 +1,13 @@
 'use strict';
 
-function setUpTaskWatch(options) {
+function setUpTaskWatch(context) {
+  if (!context.gulp) {
+    throw new Error('Context must specify gulp instance');
+  }
+  if (!context.runSequence) {
+    throw new Error('Context must specify run-sequence instance');
+  }
+
   var taskDefinition = {
     name: 'watch',
     description: ('The "watch" task performs an initial build and then serves the application on localhost at ' +
@@ -10,7 +17,7 @@ function setUpTaskWatch(options) {
     checks: [],
     options: [],
     onInit: function onInitWatchTask() {
-      var gulp          = options.gulp || require('gulp'),
+      var gulp          = context.gulp,
           watch         = require('gulp-watch'),
           watchSequence = require('gulp-watch-sequence');
 
@@ -45,12 +52,12 @@ function setUpTaskWatch(options) {
       });
     },
     onRun: function onRunWatchTask() {
-      var gulp        = options.gulp || require('gulp');
+      var gulp        = context.gulp;
       gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
 
-  options.taskYargsRun.taskYargs.register(taskDefinition);
+  return taskDefinition;
 }
 
 module.exports = setUpTaskWatch;

--- a/tasks/webstorm.js
+++ b/tasks/webstorm.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function setUpWebStormTask(tyRun) {
+function setUpWebStormTask(options) {
   var fs              = require('fs'),
       path            = require('path'),
       ideTemplate     = require('ide-template'),
@@ -174,7 +174,7 @@ function setUpWebStormTask(tyRun) {
     checks: [validateLaunchPath, checkWebstormFlags],
     options: webstormOptionDefinitions,
     onInit: function onInitWebstormTask(yargsInstance) {
-      var gulp            = require('gulp'),
+      var gulp            = options.gulp || require('gulp'),
           gutil           = require('gulp-util'),
           runSequence     = require('run-sequence');
 
@@ -333,12 +333,12 @@ function setUpWebStormTask(tyRun) {
       }
     },
     onRun: function onRunWebstormTask() {
-      var runSequence = require('run-sequence');
-      runSequence(taskDefinition.name);
+      var gulp        = options.gulp || require('gulp');
+      gulp.run(taskDefinition.name);
     }
   };
 
-  tyRun.taskYargs.register(taskDefinition);
+  options.taskYargsRun.taskYargs.register(taskDefinition);
 
   /**
    * Validator function for an angularity project being present in the current working directory

--- a/tasks/webstorm.js
+++ b/tasks/webstorm.js
@@ -343,7 +343,7 @@ function setUpWebStormTask(context) {
     },
     onRun: function onRunWebstormTask() {
       var gulp        = context.gulp;
-      gulp.start.apply(gulp, [taskDefinition.name]);
+      gulp.start(taskDefinition.name);
     }
   };
 
@@ -357,8 +357,8 @@ function setUpWebStormTask(context) {
   function angularityProjectPresent(argv) { // Todo @impaler move method to util location
     var projectPath = (argv.subdir) ? path.join(argv.subdir, 'angularity.json') : 'angularity.json';
     if (!fs.existsSync(path.resolve(projectPath))) {
-      return 'Current working directory (or specified subdir) is not a valid angularity project. Try running the ' +
-        '"init" command first.';
+      return 'Current working directory (or specified subdir) is not a valid angularity project.' +
+        'Try running the "init" command first.';
     }
   }
 

--- a/tasks/webstorm.js
+++ b/tasks/webstorm.js
@@ -87,6 +87,8 @@ function setUpWebStormTask(options) {
   ];
 
   function checkWebstormFlags(argv) {
+    var tyRun = options.taskYargsRun;
+
     if (argv.help) {
       return true;
     }
@@ -334,7 +336,7 @@ function setUpWebStormTask(options) {
     },
     onRun: function onRunWebstormTask() {
       var gulp        = options.gulp || require('gulp');
-      gulp.run(taskDefinition.name);
+      gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
 

--- a/tasks/webstorm.js
+++ b/tasks/webstorm.js
@@ -1,6 +1,13 @@
 'use strict';
 
-function setUpWebStormTask(options) {
+function setUpWebStormTask(context) {
+  if (!context.gulp) {
+    throw new Error('Context must specify gulp instance');
+  }
+  if (!context.runSequence) {
+    throw new Error('Context must specify run-sequence instance');
+  }
+
   var fs              = require('fs'),
       path            = require('path'),
       ideTemplate     = require('ide-template'),
@@ -87,7 +94,7 @@ function setUpWebStormTask(options) {
   ];
 
   function checkWebstormFlags(argv) {
-    var tyRun = options.taskYargsRun;
+    var tyRun = context.taskYargsRun;
 
     if (argv.help) {
       return true;
@@ -176,7 +183,7 @@ function setUpWebStormTask(options) {
     checks: [validateLaunchPath, checkWebstormFlags],
     options: webstormOptionDefinitions,
     onInit: function onInitWebstormTask(yargsInstance) {
-      var gulp            = options.gulp || require('gulp'),
+      var gulp            = context.gulp,
           gutil           = require('gulp-util'),
           runSequence     = require('run-sequence');
 
@@ -335,12 +342,12 @@ function setUpWebStormTask(options) {
       }
     },
     onRun: function onRunWebstormTask() {
-      var gulp        = options.gulp || require('gulp');
+      var gulp        = context.gulp;
       gulp.start.apply(gulp, [taskDefinition.name]);
     }
   };
 
-  options.taskYargsRun.taskYargs.register(taskDefinition);
+  return taskDefinition;
 
   /**
    * Validator function for an angularity project being present in the current working directory
@@ -375,4 +382,5 @@ function setUpWebStormTask(options) {
     return result;
   }
 }
+
 module.exports = setUpWebStormTask;

--- a/test/helpers/cli-test.js
+++ b/test/helpers/cli-test.js
@@ -389,13 +389,18 @@ function factory(base) {
         if (platform.isWindows()) {
           childProcess.spawn('taskkill', ['/f', '/t', '/PID', child.pid]);
         } else {
-          psTree(child.pid, function onProcessTree(err, children) {
-            var pidList = children
-              .map(function getChildPID(child) {
-                return child.PID;
-              })
-              .concat(child.pid);
-            childProcess.spawn('kill', ['-9'].concat(pidList));
+          psTree(child.pid, function onProcessTree(err, processChildren) {
+            //NOTE sometimes child may have been killed or completed
+            // in between, and callback does execute on process.nextTick
+            if (child) {
+              var pidList = processChildren
+                .map(function getChildPID(processChild) {
+                  return processChild.PID;
+                });
+              pidList = pidList
+                .concat(child.pid);
+              childProcess.spawn('kill', ['-9'].concat(pidList));
+            }
           });
         }
       }

--- a/test/helpers/cli-test.js
+++ b/test/helpers/cli-test.js
@@ -396,8 +396,7 @@ function factory(base) {
               var pidList = processChildren
                 .map(function getChildPID(processChild) {
                   return processChild.PID;
-                });
-              pidList = pidList
+                })
                 .concat(child.pid);
               childProcess.spawn('kill', ['-9'].concat(pidList));
             }


### PR DESCRIPTION
- adds a flexible/ extensible plugin registry system
- uses this for all currently included tasks
- stepping stone for splitting each of the tasks into its own module
  - main point of note is that gulp instance is passed into the task from the main application (and any other module may be passed in in a similar manner)

Minor:

- no longer depends on `run-sequence` to trigger gulp tasks
- further optimised the initial load time
- fixed minor glitch in killing child process by PID in test helper