### PR TITLE
Bugfix for sass url encoding

### DIFF
--- a/lib/build/node-sass.js
+++ b/lib/build/node-sass.js
@@ -86,7 +86,7 @@ function encodeRelativeURL(startPath, uri) {
         var type     = mime.lookup(fullPath);
         var contents = fs.readFileSync(fullPath);
         var base64   = new Buffer(contents).toString('base64');
-        return 'url(data:' + type + ';base64,' + base64 + ')';
+        return 'data:' + type + ';base64,' + base64;
       }
       // enqueue subdirectories that are not packages and are not in the root path
       else {
@@ -163,12 +163,35 @@ module.exports = function (bannerWidth, libraryPaths) {
           var sassDir = path.dirname(sassStart.source);
 
           // allow multiple url() values in the declaration
-          //  the uri will be every second value (i % 2)
+          //  split by url statements and process the content
+          //  additional capture groups are needed to match quotations correctly
+          //  escaped quotations are not considered
           declaration.value = declaration.value
-            .split(/url\s*\(\s*['"]?([^'"?#]*)[^)]*\)/g)  // split by url statements
-            .map(function (token, i) {
-              return (i % 2) ? (encodeRelativeURL(sassDir, token) || ('url(' + token + ')')) : token;
-            }).join('');
+            .split(/(url\s*\(\s*)(['"]?)((?:(?!\2|\?|#]).)*(?:(?!\2).)*)(\2\s*\))/g)
+            .map(eachSplitOrGroup)
+            .join('');
+
+          /**
+           * Encode the content portion of <code>url()</code> statements.
+           * There are 4 capture groups in the split making every 5th unmatched.
+           * @param {string} token A single split item
+           * @param i The index of the item in the split
+           * @returns {string} Every 3 or 5 items is an encoded url everything else is as is
+           */
+          function eachSplitOrGroup(token, i) {
+
+            // the quoted or unquoted content of the url() statement
+            if (i % 5 === 3) {
+
+              // remove query string or hash suffix
+              var uri = token.split(/[?#]/g).shift();
+              return encodeRelativeURL(sassDir, uri) || token;
+            }
+            // everything else, including parentheses and quotation (where present) and media statements
+            else {
+              return token;
+            }
+          }
         });
       });
     }

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "jshint-stylish": "^1.0.1",
     "ncp": "~2.0.0",
     "ps-tree": "~0.0.3",
-    "angularity-helloworld-es5": "angularity/angularity-helloworld-es5#ci-build",
-    "angularity-todo-es5": "angularity/angularity-todo-es5#ci-build"
+    "angularity-helloworld-es5": "angularity/angularity-helloworld-es5#ci-build-0.2.0-A",
+    "angularity-todo-es5": "angularity/angularity-todo-es5#ci-build-0.2.0-C"
   }
 }


### PR DESCRIPTION
Primarily encountered as a problem with inline SVG styles but had the possibility of other failures in normal URLs

~~This is expected to fail CI until the `CI-build` branch is rebuilt on `angularity-todo-es5` and possibly `angularity-helloworld-es5`. Since that would then fail CI on `master` we should perhaps merge this PR only when it will be immediately merged to `master`.~~EDIT: not a problem anymore, as soon as CI passes here we can merge