### PR TITLE
json support using browserify core functionality

### DIFF
--- a/lib/build/browserify.js
+++ b/lib/build/browserify.js
@@ -286,44 +286,47 @@ module.exports = create;
  */
 function requireTransform(allowBowerRelative, allowProjectRelative) {
   var BOWER = path.relative(process.cwd(), bowerDir.sync());
-  return transformTools.makeRequireTransform('requireTransform', null, function transform(args, opts, done) {
+  var transformOpts = {
+    excludeExtensions: ['json']  // must exclude any extension that is not javascript once all transforms have run
+  };
+  return transformTools.makeRequireTransform('requireTransform', transformOpts, function transform(args, opts, done) {
 
     // find the original path and transform it so log as it is not relative
     var original    = args[0];
-    var split       = original.split(/[\\\/]/g);    // keep delimiters
-    var firstTerm   = split.splice(0, 1).shift();   // remove the first term from the split
-    var isTransform = (firstTerm.length) && !(/^\.{1,2}$/.test(firstTerm));
+    var split       = original.split(/[\\\/]/g);                            // keep delimiters
+    var firstTerm   = split.splice(0, 1).shift();                           // remove the first term from the split
+    var isTransform = (firstTerm.length) && !(/^\.{1,2}$/.test(firstTerm)); // must not be relative
 
     // first valid result wins
     //  if we are not transforming then we fall back to the original value
     var transformed = [
 
-        // current project
-        isTransform && allowProjectRelative && function resolveProjectRelative() {
-          var packageJson = require(path.resolve('package.json'));
-          if ((typeof packageJson.name === 'string') && (packageJson.name === firstTerm)) {
-            return slash(path.resolve(path.join.apply(path, split)));  // full path to second term onwards
-          }
-        },
+      // current project
+      isTransform && allowProjectRelative && function resolveProjectRelative() {
+        var packageJson = require(path.resolve('package.json'));
+        if ((typeof packageJson.name === 'string') && (packageJson.name === firstTerm)) {
+          return slash(path.resolve(path.join.apply(path, split)));  // full path to second term onwards
+        }
+      },
 
-        // bower project
-        isTransform && allowBowerRelative && function resolveBowerRelative() {
-          var partial   = path.dirname(original);
-          var directory = (partial !== '.') && path.resolve(path.join(BOWER, partial));
-          var isFound   = directory && fs.existsSync(directory) && fs.statSync(directory).isDirectory();
-          if (isFound) {
-            return slash(path.resolve(path.join(BOWER, original)));  // path is within the bower directory
-          }
-        },
+      // bower project
+      isTransform && allowBowerRelative && function resolveBowerRelative() {
+        var partial   = path.dirname(original);
+        var directory = (partial !== '.') && path.resolve(path.join(BOWER, partial));
+        var isFound   = directory && fs.existsSync(directory) && fs.statSync(directory).isDirectory();
+        if (isFound) {
+          return slash(path.resolve(path.join(BOWER, original)));  // path is within the bower directory
+        }
+      },
 
-        // fall back value
-        original
-      ]
-        .map(function (candidate) {
-          return (typeof candidate === 'function') ? candidate() : candidate;
-        })
-        .filter(Boolean)
-        .shift();
+      // fallback value
+      original
+    ]
+      .map(function (candidate) {
+        return (typeof candidate === 'function') ? candidate() : candidate;
+      })
+      .filter(Boolean)
+      .shift();
 
     // update
     done(null, 'require("' + transformed + '")');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1869,14 +1869,14 @@
       }
     },
     "browserify-anonymous-labeler": {
-      "version": "1.2.0",
-      "from": "browserify-anonymous-labeler@1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-anonymous-labeler/-/browserify-anonymous-labeler-1.2.0.tgz"
+      "version": "1.2.2",
+      "from": "browserify-anonymous-labeler@1.2.2",
+      "resolved": "https://registry.npmjs.org/browserify-anonymous-labeler/-/browserify-anonymous-labeler-1.2.2.tgz"
     },
     "browserify-esprima-tools": {
-      "version": "1.3.0",
-      "from": "browserify-esprima-tools@1.3.0",
-      "resolved": "https://registry.npmjs.org/browserify-esprima-tools/-/browserify-esprima-tools-1.3.0.tgz",
+      "version": "1.5.0",
+      "from": "browserify-esprima-tools@1.5.0",
+      "resolved": "https://registry.npmjs.org/browserify-esprima-tools/-/browserify-esprima-tools-1.5.0.tgz",
       "dependencies": {
         "escodegen": {
           "version": "1.6.1",
@@ -1936,34 +1936,35 @@
     },
     "browserify-incremental-plugin": {
       "version": "1.0.1",
-      "from": "browserify-incremental-plugin@1.0.0"
+      "from": "browserify-incremental-plugin@1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-incremental-plugin/-/browserify-incremental-plugin-1.0.1.tgz"
     },
     "browserify-nginject": {
-      "version": "1.3.1",
-      "from": "browserify-nginject@1.3.1",
-      "resolved": "https://registry.npmjs.org/browserify-nginject/-/browserify-nginject-1.3.1.tgz"
+      "version": "1.3.2",
+      "from": "browserify-nginject@1.3.2",
+      "resolved": "https://registry.npmjs.org/browserify-nginject/-/browserify-nginject-1.3.2.tgz"
     },
     "browserify-transform-tools": {
-      "version": "1.2.2",
-      "from": "https://registry.npmjs.org/browserify-transform-tools/-/browserify-transform-tools-1.2.2.tgz",
-      "resolved": "https://registry.npmjs.org/browserify-transform-tools/-/browserify-transform-tools-1.2.2.tgz",
+      "version": "1.3.3",
+      "from": "browserify-transform-tools@1.3.3",
+      "resolved": "https://registry.npmjs.org/browserify-transform-tools/-/browserify-transform-tools-1.3.3.tgz",
       "dependencies": {
-        "through": {
-          "version": "2.3.6",
-          "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
-        },
         "falafel": {
-          "version": "0.3.1",
-          "from": "https://registry.npmjs.org/falafel/-/falafel-0.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.3.1.tgz",
+          "version": "1.0.1",
+          "from": "falafel@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.0.1.tgz",
           "dependencies": {
-            "esprima": {
-              "version": "1.1.0-dev",
-              "from": "git://github.com/substack/esprima#is-keyword",
-              "resolved": "git://github.com/substack/esprima#0a7f8489a11b44b019ce168506f535f22d0be290"
+            "acorn": {
+              "version": "0.11.0",
+              "from": "acorn@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
             }
           }
+        },
+        "through": {
+          "version": "2.3.7",
+          "from": "through@>=2.3.6 <2.4.0",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
         }
       }
     },
@@ -2448,9 +2449,9 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
     },
     "esmangleify": {
-      "version": "1.1.3",
-      "from": "esmangleify@1.1.3",
-      "resolved": "https://registry.npmjs.org/esmangleify/-/esmangleify-1.1.3.tgz",
+      "version": "1.1.4",
+      "from": "esmangleify@1.1.4",
+      "resolved": "https://registry.npmjs.org/esmangleify/-/esmangleify-1.1.4.tgz",
       "dependencies": {
         "esmangle": {
           "version": "1.0.1",
@@ -2520,15 +2521,15 @@
                   "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                 }
               }
-            },
-            "esprima": {
-              "version": "1.1.1",
-              "from": "esprima@>=1.1.1 <1.2.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
             }
           }
         }
       }
+    },
+    "esprima": {
+      "version": "1.1.1",
+      "from": "esprima@1.1.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
     },
     "esutils": {
       "version": "1.1.6",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1940,9 +1940,9 @@
       "resolved": "https://registry.npmjs.org/browserify-incremental-plugin/-/browserify-incremental-plugin-1.0.1.tgz"
     },
     "browserify-nginject": {
-      "version": "1.3.2",
-      "from": "browserify-nginject@1.3.2",
-      "resolved": "https://registry.npmjs.org/browserify-nginject/-/browserify-nginject-1.3.2.tgz"
+      "version": "1.3.3",
+      "from": "browserify-nginject@1.3.3",
+      "resolved": "https://registry.npmjs.org/browserify-nginject/-/browserify-nginject-1.3.3.tgz"
     },
     "browserify-transform-tools": {
       "version": "1.3.3",

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -221,7 +221,7 @@ function setUpTaskJavascript(context) {
         return [
           babelify.configure({ignore: /(?!)/}),   // convert any es6 to es5 (degenerate regex)
           stringify({minify: false}),             // allow import of html to a string
-          ngInject(),                             // annotate dependencies for angular
+          ngInject({filter: /\.(?!json)\w+$/}),   // annotate dependencies for angular (everything except .json)
           isMinify && esmangleify()               // minify
         ].filter(Boolean);
         // TODO @bholloway fix stringify({ minify: true }) throwing error on badly formed html so that we can minify


### PR DESCRIPTION
Had to adjust transforms to allow non-`js` content to pass through without crashing Esprima.

Limitation of using `transformTools. makeRequireTransform()` is that we have to ignore `json` wholesale. This shouldn't be a problem as I believe Browserify treats `json` very simply and therefore does not support `require()` statements within it.