### PR TITLE
fixed performance deficit in initial JS compile

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1935,9 +1935,9 @@
       }
     },
     "browserify-incremental-plugin": {
-      "version": "1.0.2",
-      "from": "browserify-incremental-plugin@1.0.2",
-      "resolved": "https://registry.npmjs.org/browserify-incremental-plugin/-/browserify-incremental-plugin-1.0.2.tgz"
+      "version": "1.0.3",
+      "from": "browserify-incremental-plugin@1.0.3",
+      "resolved": "https://registry.npmjs.org/browserify-incremental-plugin/-/browserify-incremental-plugin-1.0.3.tgz"
     },
     "browserify-nginject": {
       "version": "1.4.1",


### PR DESCRIPTION
There was an issue with the `browserify-incremental-plugin` which meant that initial JS compilation of multiple composition roots was slower than it could be.

Where you have multiple compositions with `require`'d files in common, those files should only be compiled once overall, even on initial compile of each composition.